### PR TITLE
Bump actions/download-artifact from 1 to 4.1.7 in /.github/workflows

### DIFF
--- a/.github/workflows/mla_release.yml
+++ b/.github/workflows/mla_release.yml
@@ -116,27 +116,27 @@ jobs:
           draft: true
 
       - name: Download linux-x86_64 artifact
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4.1.7
         with:
           name: mla-linux-x86_64
 
       - name: Download windows-i686 artifact
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4.1.7
         with:
           name: mla-windows-i686
 
       - name: Download windows-x86_64 artifact
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4.1.7
         with:
           name: mla-windows-x86_64
 
       - name: Download windows-i686-debug artifact
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4.1.7
         with:
           name: mla-windows-i686-debug
 
       - name: Download windows-x86_64-debug artifact
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4.1.7
         with:
           name: mla-windows-x86_64-debug
 

--- a/.github/workflows/mlar_release.yml
+++ b/.github/workflows/mlar_release.yml
@@ -82,17 +82,17 @@ jobs:
           draft: true
 
       - name: Download Linux artifact
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4.1.7
         with:
           name: mlar-linux
 
       - name: Download Windows artifact
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4.1.7
         with:
           name: mlar-windows
 
       - name: Download MacOS artifact
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4.1.7
         with:
           name: mlar-macos
 


### PR DESCRIPTION
### Description

In this pull request, the GitHub Actions workflow files `.github/workflows/mla_release.yml` and `.github/workflows/mlar_release.yml` have been modified to update the version of the `actions/download-artifact` action being used.

Changes:
- Updated the version of `actions/download-artifact` from `v1` to `v4.1.7` for all download artifact steps in the workflow files.

These changes were made to ensure compatibility with the latest features and improvements provided by the updated version of the `actions/download-artifact` action.